### PR TITLE
Add basic features to WebFriend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+Flask-Login

--- a/webfriends/models.py
+++ b/webfriends/models.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+db = SQLAlchemy()
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    city = db.Column(db.String(120))
+    status = db.Column(db.String(120))
+    interests = db.Column(db.String(250))
+    lat = db.Column(db.Float)
+    lng = db.Column(db.Float)
+
+    def set_password(self, password: str):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(120))
+    description = db.Column(db.String(250))
+    lat = db.Column(db.Float)
+    lng = db.Column(db.Float)
+    creator_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+
+class Like(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    target_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    liked = db.Column(db.Boolean, default=True)
+
+class Message(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    text = db.Column(db.Text)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Gift(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80))
+    description = db.Column(db.String(200))
+
+class UserGift(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    gift_id = db.Column(db.Integer, db.ForeignKey('gift.id'))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)

--- a/webfriends/templates/chat.html
+++ b/webfriends/templates/chat.html
@@ -1,27 +1,15 @@
 {% extends 'layout.html' %}
 {% block content %}
-<h2 class="title is-4 mb-3">SpeedMeet (демо)</h2>
-<p>Откройте эту страницу в двух окнах браузера для демонстрации видеосвязи.</p>
-<video id="local" autoplay playsinline muted class="box"></video>
-<video id="remote" autoplay playsinline class="box mt-4"></video>
-<script>
-let pc = new RTCPeerConnection();
-let local = document.getElementById('local');
-let remote = document.getElementById('remote');
-navigator.mediaDevices.getUserMedia({video:true,audio:true}).then(stream=>{
-  local.srcObject = stream;
-  stream.getTracks().forEach(t=>pc.addTrack(t,stream));
-  pc.createOffer().then(o=>pc.setLocalDescription(o));
-});
-pc.ontrack = ev => { remote.srcObject = ev.streams[0]; };
-window.onhashchange = async ()=>{
-  if(location.hash.startsWith('#')){
-    let offer = JSON.parse(atob(location.hash.slice(1)));
-    await pc.setRemoteDescription(offer);
-    let ans = await pc.createAnswer();
-    await pc.setLocalDescription(ans);
-    alert('Скопируйте эту ссылку и откройте в другом окне:\n'+location.origin+location.pathname+'#'+btoa(JSON.stringify(ans)));
-  }
-};
-</script>
+<h2 class="title is-4 mb-3">Чат с {{ other.username }}</h2>
+<div class="box" style="max-height:300px; overflow-y:auto;">
+  {% for m in messages %}
+    <p><b>{{ 'Вы' if m.sender_id==current_user.id else other.username }}:</b> {{ m.text }}</p>
+  {% endfor %}
+</div>
+<form method="post" class="mt-4">
+  <b-field>
+    <b-input name="text" required></b-input>
+  </b-field>
+  <button class="button is-primary" type="submit">Отправить</button>
+</form>
 {% endblock %}

--- a/webfriends/templates/layout.html
+++ b/webfriends/templates/layout.html
@@ -14,6 +14,13 @@
 <div id="app">
     <section class="section">
         <div class="container">
+            <div class="is-flex is-justify-content-flex-end mb-2">
+                {% if current_user.is_authenticated %}
+                    <a href="{{ url_for('logout') }}">Выход</a>
+                {% else %}
+                    <a href="{{ url_for('login') }}">Вход</a>
+                {% endif %}
+            </div>
             {% block content %}{% endblock %}
         </div>
     </section>
@@ -22,14 +29,14 @@
             <a class="navbar-item has-text-white" href="/">
                 <span class="icon is-large"><i class="fas fa-home"></i></span>
             </a>
-            <a class="navbar-item has-text-white" href="/cards">
+            <a class="navbar-item has-text-white" href="/swipe">
                 <span class="icon is-large"><i class="fas fa-heart"></i></span>
             </a>
             <a class="navbar-item has-text-white" href="/map">
                 <span class="icon is-large"><i class="fas fa-map-marker-alt"></i></span>
             </a>
-            <a class="navbar-item has-text-white" href="/chat">
-                <span class="icon is-large"><i class="fas fa-comments"></i></span>
+            <a class="navbar-item has-text-white" href="/feed">
+                <span class="icon is-large"><i class="fas fa-stream"></i></span>
             </a>
             <a class="navbar-item has-text-white" href="/profile">
                 <span class="icon is-large"><i class="fas fa-user"></i></span>

--- a/webfriends/templates/login.html
+++ b/webfriends/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-4">Вход</h2>
+<form method="post">
+  <b-field label="Имя пользователя">
+    <b-input name="username" required></b-input>
+  </b-field>
+  <b-field label="Пароль">
+    <b-input name="password" type="password" required></b-input>
+  </b-field>
+  <div class="mt-4">
+    <button class="button is-primary" type="submit">Войти</button>
+    <a href="{{ url_for('register') }}" class="button is-text">Регистрация</a>
+  </div>
+</form>
+{% endblock %}

--- a/webfriends/templates/profile.html
+++ b/webfriends/templates/profile.html
@@ -2,8 +2,8 @@
 {% block content %}
 <h2 class="title is-4 mb-4">Профиль</h2>
 <form method="post">
-  <b-field label="Имя">
-    <b-input name="name" value="{{ user.name }}"></b-input>
+  <b-field label="Имя пользователя">
+    <b-input :value="user.username" disabled></b-input>
   </b-field>
   <b-field label="Город">
     <b-input name="city" value="{{ user.city }}"></b-input>

--- a/webfriends/templates/register.html
+++ b/webfriends/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-4">Регистрация</h2>
+<form method="post">
+  <b-field label="Имя пользователя">
+    <b-input name="username" required></b-input>
+  </b-field>
+  <b-field label="Пароль">
+    <b-input name="password" type="password" required></b-input>
+  </b-field>
+  <div class="mt-4">
+    <button class="button is-primary" type="submit">Создать аккаунт</button>
+  </div>
+</form>
+{% endblock %}

--- a/webfriends/templates/send_gift.html
+++ b/webfriends/templates/send_gift.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-4">Отправить подарок {{ target.username }}</h2>
+<form method="post">
+  <b-field label="Подарок">
+    <b-select name="gift_id">
+      {% for g in gifts %}
+      <option value="{{ g.id }}">{{ g.name }}</option>
+      {% endfor %}
+    </b-select>
+  </b-field>
+  <button class="button is-primary" type="submit">Отправить</button>
+</form>
+{% endblock %}

--- a/webfriends/templates/swipe.html
+++ b/webfriends/templates/swipe.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-3">Поиск друзей</h2>
+{% if target %}
+<div class="box has-text-centered">
+  <p class="title is-5">{{ target.username }}</p>
+  <p>{{ target.city }}</p>
+  <div class="mt-3">
+    <a class="button is-success" href="{{ url_for('like_user', user_id=target.id, action='like') }}">Нравится</a>
+    <a class="button is-danger" href="{{ url_for('like_user', user_id=target.id, action='dislike') }}">Пропустить</a>
+  </div>
+</div>
+{% else %}
+<p>Больше пользователей нет.</p>
+{% endif %}
+{% endblock %}

--- a/webfriends_app.py
+++ b/webfriends_app.py
@@ -1,25 +1,66 @@
-from flask import Flask, render_template, jsonify, request, redirect
+from flask import Flask, render_template, jsonify, request, redirect, url_for, flash
+from flask_login import LoginManager, login_user, login_required, logout_user, current_user
+from webfriends.models import db, User, Event, Like, Message, Gift, UserGift
 
 app = Flask(__name__, template_folder='webfriends/templates', static_folder='webfriends/static')
+app.config['SECRET_KEY'] = 'dev'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///webfriends.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-# Демонстрационные данные
-EVENTS = [
-    {"id": 1, "lat": 55.751244, "lng": 37.618423, "title": "Кофе в парке", "description": "Ищу компанию для настолок"},
-    {"id": 2, "lat": 55.757, "lng": 37.615, "title": "Гуляем с собакой", "description": "Присоединяйся!"},
-    {"id": 3, "lat": 55.75, "lng": 37.605, "title": "Бег по набережной", "description": "Легкая пробежка"}
-]
+db.init_app(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
 
-USER = {"name": "", "city": "", "status": "", "interests": ""}
+@login_manager.user_loader
+def load_user(user_id):
+    return db.session.get(User, int(user_id))
 
 CARDS = [
     {"id": 1, "image": "https://source.unsplash.com/random/400x300?sig=1", "question": "Выбери мем, который тебе ближе"},
     {"id": 2, "image": "https://source.unsplash.com/random/400x300?sig=2", "question": "Какую музыку ты слушаешь?"},
-    {"id": 3, "image": "https://source.unsplash.com/random/400x300?sig=3", "question": "Любимое место в городе?"}
+    {"id": 3, "image": "https://source.unsplash.com/random/400x300?sig=3", "question": "Любимое место в городе?"},
 ]
 
 @app.route('/')
 def index():
     return render_template('index.html', title='ВебДрузья')
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('Имя пользователя занято')
+        else:
+            user = User(username=username)
+            user.set_password(password)
+            db.session.add(user)
+            db.session.commit()
+            login_user(user)
+            return redirect(url_for('profile_view'))
+    return render_template('register.html', title='Регистрация')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Неверные учетные данные')
+    return render_template('login.html', title='Вход')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
 
 @app.route('/map')
 def map_view():
@@ -27,48 +68,134 @@ def map_view():
 
 @app.route('/events', methods=['GET'])
 def events_api():
-    return jsonify(EVENTS)
+    events = Event.query.all()
+    return jsonify([
+        {"id": e.id, "lat": e.lat, "lng": e.lng, "title": e.title, "description": e.description}
+        for e in events
+    ])
 
 @app.route('/add_event', methods=['POST'])
 def add_event():
-    new = {
-        "id": len(EVENTS) + 1,
-        "lat": float(request.form['lat']),
-        "lng": float(request.form['lng']),
-        "title": request.form['title'],
-        "description": request.form['description'],
-    }
-    EVENTS.append(new)
+    event = Event(
+        title=request.form['title'],
+        description=request.form['description'],
+        lat=float(request.form['lat']),
+        lng=float(request.form['lng']),
+        creator_id=current_user.id if current_user.is_authenticated else None,
+    )
+    db.session.add(event)
+    db.session.commit()
     return redirect('/map')
 
 @app.route('/cards')
 def cards_view():
     return render_template('cards.html', title='Челленджи', cards=CARDS)
 
+
+@app.route('/swipe')
+@login_required
+def swipe_view():
+    user = User.query.filter(User.id != current_user.id).order_by(db.func.random()).first()
+    return render_template('swipe.html', title='Поиск друзей', target=user)
+
+
+@app.route('/like/<int:user_id>/<action>')
+@login_required
+def like_user(user_id, action):
+    target = db.session.get(User, user_id)
+    if not target:
+        flash('Пользователь не найден')
+        return redirect(url_for('swipe_view'))
+    like = Like.query.filter_by(user_id=current_user.id, target_id=user_id).first()
+    if not like:
+        like = Like(user_id=current_user.id, target_id=user_id, liked=(action=='like'))
+        db.session.add(like)
+    else:
+        like.liked = (action=='like')
+    db.session.commit()
+    # check for match
+    if action == 'like':
+        back = Like.query.filter_by(user_id=user_id, target_id=current_user.id, liked=True).first()
+        if back:
+            flash('У вас новый матч!')
+    return redirect(url_for('swipe_view'))
+
+
+@app.route('/send_gift/<int:user_id>', methods=['GET', 'POST'])
+@login_required
+def send_gift(user_id):
+    target = db.session.get(User, user_id)
+    if not target:
+        flash('Пользователь не найден')
+        return redirect(url_for('index'))
+    gifts = Gift.query.all()
+    if request.method == 'POST':
+        gift_id = int(request.form['gift_id'])
+        g = db.session.get(Gift, gift_id)
+        if g:
+            ug = UserGift(sender_id=current_user.id, recipient_id=user_id, gift_id=gift_id)
+            db.session.add(ug)
+            db.session.commit()
+            flash('Подарок отправлен')
+            return redirect(url_for('profile_view'))
+    return render_template('send_gift.html', title='Подарок', target=target, gifts=gifts)
+
 @app.route('/feed')
 def feed_view():
-    return render_template('feed.html', title='Пульс города', feed=EVENTS)
+    events = Event.query.order_by(Event.id.desc()).all()
+    return render_template('feed.html', title='Пульс города', feed=events)
 
-@app.route('/chat')
-def chat_view():
-    return render_template('chat.html', title='SpeedMeet')
+@app.route('/chat/<int:user_id>', methods=['GET', 'POST'])
+@login_required
+def chat_view(user_id):
+    other = db.session.get(User, user_id)
+    if not other:
+        flash('Пользователь не найден')
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        text = request.form['text']
+        msg = Message(sender_id=current_user.id, recipient_id=other.id, text=text)
+        db.session.add(msg)
+        db.session.commit()
+        return redirect(url_for('chat_view', user_id=user_id))
+    messages = Message.query.filter(
+        ((Message.sender_id == current_user.id) & (Message.recipient_id == other.id)) |
+        ((Message.sender_id == other.id) & (Message.recipient_id == current_user.id))
+    ).order_by(Message.timestamp).all()
+    return render_template('chat.html', title='Чат', other=other, messages=messages)
 
 
 @app.route('/profile', methods=['GET', 'POST'])
+@login_required
 def profile_view():
     if request.method == 'POST':
-        USER['name'] = request.form.get('name', '')
-        USER['city'] = request.form.get('city', '')
-        USER['status'] = request.form.get('status', '')
-        USER['interests'] = request.form.get('interests', '')
-    return render_template('profile.html', title='Профиль', user=USER)
+        current_user.city = request.form.get('city', '')
+        current_user.status = request.form.get('status', '')
+        current_user.interests = request.form.get('interests', '')
+        db.session.commit()
+        flash('Профиль обновлен')
+    return render_template('profile.html', title='Профиль', user=current_user)
 
 
 @app.route('/create-event', methods=['GET', 'POST'])
+@login_required
 def create_event_view():
     if request.method == 'POST':
         return add_event()
     return render_template('create_event.html', title='Создать событие')
+
+
+@app.cli.command('initdb')
+def init_db_command():
+    with app.app_context():
+        db.create_all()
+        if not Gift.query.first():
+            db.session.add_all([
+                Gift(name='Цветок', description='Виртуальный цветок'),
+                Gift(name='Сердце', description='Смайлик-сердечко'),
+            ])
+            db.session.commit()
+        print('Database initialized')
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- add Flask auth, database models, and helper CLI to init sample data
- enable user registration, login, logout and profile editing
- implement swipe with like/match logic and chat messaging
- allow sending gifts between users
- update layout with login/logout links and new navigation

## Testing
- `pip install -r requirements.txt`
- `flask --app webfriends_app.py initdb`
- `python3 -m py_compile webfriends_app.py webfriends/models.py`


------
https://chatgpt.com/codex/tasks/task_e_685a46d76e3883309040ac3229db62ae