### PR TITLE
Add matches and confirmation features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+webfriends/static/uploads/
+*.db

--- a/webfriends/models.py
+++ b/webfriends/models.py
@@ -9,11 +9,23 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    email = db.Column(db.String(120))
+    phone = db.Column(db.String(30))
+    gender = db.Column(db.String(20))
+    age = db.Column(db.Integer)
     city = db.Column(db.String(120))
     status = db.Column(db.String(120))
     interests = db.Column(db.String(250))
+    about = db.Column(db.Text)
+    photo = db.Column(db.String(200))
+    is_private = db.Column(db.Boolean, default=False)
     lat = db.Column(db.Float)
     lng = db.Column(db.Float)
+    social = db.Column(db.String(250))
+    email_confirmed = db.Column(db.Boolean, default=False)
+    phone_confirmed = db.Column(db.Boolean, default=False)
+    email_token = db.Column(db.String(120))
+    phone_token = db.Column(db.String(120))
 
     def set_password(self, password: str):
         self.password_hash = generate_password_hash(password)
@@ -53,3 +65,11 @@ class UserGift(db.Model):
     recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     gift_id = db.Column(db.Integer, db.ForeignKey('gift.id'))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Match(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user1_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    user2_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/webfriends/static/js/map.js
+++ b/webfriends/static/js/map.js
@@ -2,9 +2,31 @@ let map = L.map('map').setView([55.751244, 37.618423], 12);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; OpenStreetMap'
 }).addTo(map);
+let markers = [];
 fetch('/events').then(r=>r.json()).then(data=>{
-    data.forEach(ev=>{
-        L.marker([ev.lat, ev.lng]).addTo(map)
-            .bindPopup(`<b>${ev.title}</b><br>${ev.description}`);
+    data.forEach(item=>{
+        const marker = L.marker([item.lat, item.lng]).addTo(map);
+        marker.bindPopup(`<b>${item.title}</b><br>${item.description || ''}`);
+        marker.item = item;
+        markers.push(marker);
     });
 });
+
+function applyFilters(){
+    const term = document.getElementById('search').value.toLowerCase();
+    const gender = document.getElementById('filterGender').value;
+    markers.forEach(m => {
+        let visible = m.item.title.toLowerCase().includes(term);
+        if(gender && m.item.type === 'user'){
+            visible = visible && m.item.gender === gender;
+        }
+        if(visible){
+            m.addTo(map);
+        }else{
+            map.removeLayer(m);
+        }
+    });
+}
+
+document.getElementById('search').addEventListener('input', applyFilters);
+document.getElementById('filterGender').addEventListener('change', applyFilters);

--- a/webfriends/templates/change_password.html
+++ b/webfriends/templates/change_password.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-4">Смена пароля</h2>
+<form method="post">
+  <b-field label="Текущий пароль">
+    <b-input name="old_password" type="password" required></b-input>
+  </b-field>
+  <b-field label="Новый пароль">
+    <b-input name="new_password" type="password" required></b-input>
+  </b-field>
+  <div class="mt-4">
+    <button class="button is-primary" type="submit">Изменить</button>
+  </div>
+</form>
+{% endblock %}

--- a/webfriends/templates/layout.html
+++ b/webfriends/templates/layout.html
@@ -38,6 +38,9 @@
             <a class="navbar-item has-text-white" href="/feed">
                 <span class="icon is-large"><i class="fas fa-stream"></i></span>
             </a>
+            <a class="navbar-item has-text-white" href="/matches">
+                <span class="icon is-large"><i class="fas fa-handshake"></i></span>
+            </a>
             <a class="navbar-item has-text-white" href="/profile">
                 <span class="icon is-large"><i class="fas fa-user"></i></span>
             </a>

--- a/webfriends/templates/map.html
+++ b/webfriends/templates/map.html
@@ -1,6 +1,22 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2 class="title is-4 mb-3">Гео-Карта живых событий</h2>
+<div class="columns">
+  <div class="column">
+    <b-field label="Поиск">
+      <b-input id="search" placeholder="Название"></b-input>
+    </b-field>
+  </div>
+  <div class="column">
+    <b-field label="Пол">
+      <b-select id="filterGender">
+        <option value="">Любой</option>
+        <option value="male">Мужской</option>
+        <option value="female">Женский</option>
+      </b-select>
+    </b-field>
+  </div>
+</div>
 <div id="map" style="height:500px;"></div>
 <a href="/create-event" class="button is-primary fab">
     <span class="icon"><i class="fas fa-plus"></i></span>

--- a/webfriends/templates/matches.html
+++ b/webfriends/templates/matches.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-4">Мои матчи</h2>
+{% if users %}
+<ul>
+  {% for u in users %}
+  <li><a href="{{ url_for('chat_view', user_id=u.id) }}">{{ u.username }}</a></li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>Матчей пока нет.</p>
+{% endif %}
+{% endblock %}

--- a/webfriends/templates/profile.html
+++ b/webfriends/templates/profile.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2 class="title is-4 mb-4">Профиль</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <b-field label="Имя пользователя">
     <b-input :value="user.username" disabled></b-input>
   </b-field>
@@ -14,8 +14,35 @@
   <b-field label="Интересы">
     <b-input name="interests" value="{{ user.interests }}"></b-input>
   </b-field>
-  <div class="mt-4">
-    <button class="button is-primary" type="submit">Сохранить</button>
+  <b-field label="О себе">
+    <b-input name="about" value="{{ user.about }}"></b-input>
+  </b-field>
+  <b-field label="Соцсети">
+    <b-input name="social" value="{{ user.social }}"></b-input>
+  </b-field>
+  <b-field label="Фото профиля">
+    <b-input name="photo" type="file" accept="image/*"></b-input>
+  </b-field>
+  <b-field label="Режим невидимки">
+    <b-switch name="is_private" {{ 'checked' if user.is_private else '' }}></b-switch>
+  </b-field>
+  <b-field label="Широта">
+    <b-input name="lat" value="{{ user.lat }}" type="number" step="any"></b-input>
+  </b-field>
+  <b-field label="Долгота">
+    <b-input name="lng" value="{{ user.lng }}" type="number" step="any"></b-input>
+  </b-field>
+  {% if user.photo %}
+  <div class="mb-3">
+    <img src="{{ url_for('static', filename='uploads/' + user.photo) }}" style="max-width:150px;">
   </div>
+  {% endif %}
+<div class="mt-4">
+  <button class="button is-primary" type="submit">Сохранить</button>
+</div>
 </form>
+<div class="mt-4">
+  <a href="{{ url_for('change_password') }}" class="button is-light">Сменить пароль</a>
+  <a href="{{ url_for('matches_view') }}" class="button is-link ml-2">Мои матчи</a>
+</div>
 {% endblock %}

--- a/webfriends/templates/register.html
+++ b/webfriends/templates/register.html
@@ -1,12 +1,37 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2 class="title is-4 mb-4">Регистрация</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <b-field label="Имя пользователя">
     <b-input name="username" required></b-input>
   </b-field>
+  <b-field label="Email">
+    <b-input name="email" type="email"></b-input>
+  </b-field>
+  <b-field label="Телефон">
+    <b-input name="phone"></b-input>
+  </b-field>
   <b-field label="Пароль">
     <b-input name="password" type="password" required></b-input>
+  </b-field>
+  <b-field label="Пол">
+    <b-select name="gender">
+      <option value="">-</option>
+      <option value="male">Мужской</option>
+      <option value="female">Женский</option>
+    </b-select>
+  </b-field>
+  <b-field label="Возраст">
+    <b-input name="age" type="number" min="18"></b-input>
+  </b-field>
+  <b-field label="О себе">
+    <b-input name="about"></b-input>
+  </b-field>
+  <b-field label="Соцсети">
+    <b-input name="social"></b-input>
+  </b-field>
+  <b-field label="Фото профиля">
+    <b-input name="photo" type="file" accept="image/*"></b-input>
   </b-field>
   <div class="mt-4">
     <button class="button is-primary" type="submit">Создать аккаунт</button>

--- a/webfriends_app.py
+++ b/webfriends_app.py
@@ -1,6 +1,9 @@
+import os
+import secrets
 from flask import Flask, render_template, jsonify, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user
-from webfriends.models import db, User, Event, Like, Message, Gift, UserGift
+from webfriends.models import db, User, Event, Like, Message, Gift, UserGift, Match
 
 app = Flask(__name__, template_folder='webfriends/templates', static_folder='webfriends/static')
 app.config['SECRET_KEY'] = 'dev'
@@ -31,14 +34,40 @@ def register():
     if request.method == 'POST':
         username = request.form['username']
         password = request.form['password']
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        gender = request.form.get('gender')
+        age = request.form.get('age')
+        about = request.form.get('about')
+        social = request.form.get('social')
+        photo_file = request.files.get('photo')
         if User.query.filter_by(username=username).first():
             flash('Имя пользователя занято')
         else:
-            user = User(username=username)
+            user = User(
+                username=username,
+                email=email,
+                phone=phone,
+                gender=gender,
+                age=int(age) if age else None,
+                about=about,
+                social=social,
+                email_token=secrets.token_urlsafe(8) if email else None,
+                phone_token=secrets.token_urlsafe(8) if phone else None,
+            )
             user.set_password(password)
+            if photo_file and photo_file.filename:
+                filename = secure_filename(photo_file.filename)
+                upload_path = os.path.join(app.static_folder, 'uploads', filename)
+                photo_file.save(upload_path)
+                user.photo = filename
             db.session.add(user)
             db.session.commit()
             login_user(user)
+            if email:
+                flash(f'Подтвердите email: {url_for("confirm_email", token=user.email_token, _external=True)}')
+            if phone:
+                flash(f'Подтвердите телефон: {url_for("confirm_phone", token=user.phone_token, _external=True)}')
             return redirect(url_for('profile_view'))
     return render_template('register.html', title='Регистрация')
 
@@ -68,11 +97,24 @@ def map_view():
 
 @app.route('/events', methods=['GET'])
 def events_api():
-    events = Event.query.all()
-    return jsonify([
-        {"id": e.id, "lat": e.lat, "lng": e.lng, "title": e.title, "description": e.description}
-        for e in events
-    ])
+    events = [
+        {"id": e.id, "lat": e.lat, "lng": e.lng, "title": e.title, "description": e.description, "type": "event"}
+        for e in Event.query.all()
+    ]
+    users = [
+        {
+            "id": u.id,
+            "lat": u.lat,
+            "lng": u.lng,
+            "title": u.username,
+            "description": u.status,
+            "type": "user",
+            "gender": u.gender,
+            "interests": u.interests,
+        }
+        for u in User.query.filter_by(is_private=False).all() if u.lat and u.lng
+    ]
+    return jsonify(events + users)
 
 @app.route('/add_event', methods=['POST'])
 def add_event():
@@ -117,6 +159,12 @@ def like_user(user_id, action):
     if action == 'like':
         back = Like.query.filter_by(user_id=user_id, target_id=current_user.id, liked=True).first()
         if back:
+            if not Match.query.filter(
+                ((Match.user1_id==current_user.id) & (Match.user2_id==user_id)) |
+                ((Match.user1_id==user_id) & (Match.user2_id==current_user.id))
+            ).first():
+                db.session.add(Match(user1_id=current_user.id, user2_id=user_id))
+                db.session.commit()
             flash('У вас новый матч!')
     return redirect(url_for('swipe_view'))
 
@@ -152,6 +200,12 @@ def chat_view(user_id):
     if not other:
         flash('Пользователь не найден')
         return redirect(url_for('index'))
+    # allow chat only for взаимных лайков
+    l1 = Like.query.filter_by(user_id=current_user.id, target_id=other.id, liked=True).first()
+    l2 = Like.query.filter_by(user_id=other.id, target_id=current_user.id, liked=True).first()
+    if not (l1 and l2):
+        flash('Чат доступен только после взаимного лайка')
+        return redirect(url_for('swipe_view'))
     if request.method == 'POST':
         text = request.form['text']
         msg = Message(sender_id=current_user.id, recipient_id=other.id, text=text)
@@ -165,6 +219,51 @@ def chat_view(user_id):
     return render_template('chat.html', title='Чат', other=other, messages=messages)
 
 
+@app.route('/matches')
+@login_required
+def matches_view():
+    matches = Match.query.filter(
+        (Match.user1_id == current_user.id) | (Match.user2_id == current_user.id)
+    ).all()
+    ids = [m.user1_id if m.user2_id == current_user.id else m.user2_id for m in matches]
+    users = User.query.filter(User.id.in_(ids)).all() if ids else []
+    return render_template('matches.html', title='Матчи', users=users)
+
+
+@app.route('/confirm_email/<token>')
+def confirm_email(token):
+    user = User.query.filter_by(email_token=token).first_or_404()
+    user.email_confirmed = True
+    user.email_token = None
+    db.session.commit()
+    flash('Email подтвержден')
+    return redirect(url_for('profile_view'))
+
+
+@app.route('/confirm_phone/<token>')
+def confirm_phone(token):
+    user = User.query.filter_by(phone_token=token).first_or_404()
+    user.phone_confirmed = True
+    user.phone_token = None
+    db.session.commit()
+    flash('Телефон подтвержден')
+    return redirect(url_for('profile_view'))
+
+
+@app.route('/change_password', methods=['GET', 'POST'])
+@login_required
+def change_password():
+    if request.method == 'POST':
+        if not current_user.check_password(request.form['old_password']):
+            flash('Неверный текущий пароль')
+        else:
+            current_user.set_password(request.form['new_password'])
+            db.session.commit()
+            flash('Пароль обновлен')
+            return redirect(url_for('profile_view'))
+    return render_template('change_password.html', title='Сменить пароль')
+
+
 @app.route('/profile', methods=['GET', 'POST'])
 @login_required
 def profile_view():
@@ -172,6 +271,17 @@ def profile_view():
         current_user.city = request.form.get('city', '')
         current_user.status = request.form.get('status', '')
         current_user.interests = request.form.get('interests', '')
+        current_user.about = request.form.get('about', '')
+        current_user.social = request.form.get('social', '')
+        current_user.is_private = bool(request.form.get('is_private'))
+        current_user.lat = request.form.get('lat') or None
+        current_user.lng = request.form.get('lng') or None
+        photo_file = request.files.get('photo')
+        if photo_file and photo_file.filename:
+            filename = secure_filename(photo_file.filename)
+            upload_path = os.path.join(app.static_folder, 'uploads', filename)
+            photo_file.save(upload_path)
+            current_user.photo = filename
         db.session.commit()
         flash('Профиль обновлен')
     return render_template('profile.html', title='Профиль', user=current_user)


### PR DESCRIPTION
## Summary
- track social, confirmation tokens, and new Match model
- filter map markers by gender
- capture social links during registration and profile edit
- add matches page and navbar link
- create email/phone confirmation routes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a4beabd0c83309b70bfbfc3c45298