### PR TITLE
Implement socket chat, SpeedMeet and map filters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask-SQLAlchemy
 Flask-Login
+Flask-SocketIO

--- a/webfriends/models.py
+++ b/webfriends/models.py
@@ -26,6 +26,9 @@ class User(UserMixin, db.Model):
     phone_confirmed = db.Column(db.Boolean, default=False)
     email_token = db.Column(db.String(120))
     phone_token = db.Column(db.String(120))
+    verification_photo = db.Column(db.String(200))
+    is_verified = db.Column(db.Boolean, default=False)
+    trusted_user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
 
     def set_password(self, password: str):
         self.password_hash = generate_password_hash(password)
@@ -37,6 +40,8 @@ class Event(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(120))
     description = db.Column(db.String(250))
+    category = db.Column(db.String(50))
+    is_safe = db.Column(db.Boolean, default=False)
     lat = db.Column(db.Float)
     lng = db.Column(db.Float)
     creator_id = db.Column(db.Integer, db.ForeignKey('user.id'))
@@ -46,6 +51,7 @@ class Like(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     target_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     liked = db.Column(db.Boolean, default=True)
+    super = db.Column(db.Boolean, default=False)
 
 class Message(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -58,6 +64,7 @@ class Gift(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80))
     description = db.Column(db.String(200))
+    coupon_url = db.Column(db.String(200))
 
 class UserGift(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -71,5 +78,12 @@ class Match(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user1_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     user2_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class Status(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    text = db.Column(db.String(250))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 

--- a/webfriends/static/js/map.js
+++ b/webfriends/static/js/map.js
@@ -3,9 +3,14 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; OpenStreetMap'
 }).addTo(map);
 let markers = [];
+const mapIcons = {
+    default: L.icon({iconUrl:'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',iconSize:[25,41],iconAnchor:[12,41]}),
+    safe: L.icon({iconUrl:'https://cdn.jsdelivr.net/gh/pointhi/leaflet-color-markers@master/img/marker-icon-green.png',iconSize:[25,41],iconAnchor:[12,41]})
+};
 fetch('/events').then(r=>r.json()).then(data=>{
     data.forEach(item=>{
-        const marker = L.marker([item.lat, item.lng]).addTo(map);
+        const icon = item.safe ? mapIcons.safe : mapIcons.default;
+        const marker = L.marker([item.lat, item.lng], {icon}).addTo(map);
         marker.bindPopup(`<b>${item.title}</b><br>${item.description || ''}`);
         marker.item = item;
         markers.push(marker);
@@ -15,10 +20,18 @@ fetch('/events').then(r=>r.json()).then(data=>{
 function applyFilters(){
     const term = document.getElementById('search').value.toLowerCase();
     const gender = document.getElementById('filterGender').value;
+    const category = document.getElementById('filterCategory').value;
+    const safeOnly = document.getElementById('filterSafe').checked;
     markers.forEach(m => {
         let visible = m.item.title.toLowerCase().includes(term);
         if(gender && m.item.type === 'user'){
             visible = visible && m.item.gender === gender;
+        }
+        if(category && m.item.type === 'event'){
+            visible = visible && m.item.category === category;
+        }
+        if(safeOnly && m.item.type === 'event'){
+            visible = visible && m.item.safe;
         }
         if(visible){
             m.addTo(map);
@@ -30,3 +43,5 @@ function applyFilters(){
 
 document.getElementById('search').addEventListener('input', applyFilters);
 document.getElementById('filterGender').addEventListener('change', applyFilters);
+document.getElementById('filterCategory').addEventListener('change', applyFilters);
+document.getElementById('filterSafe').addEventListener('change', applyFilters);

--- a/webfriends/templates/chat.html
+++ b/webfriends/templates/chat.html
@@ -1,15 +1,35 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2 class="title is-4 mb-3">Чат с {{ other.username }}</h2>
-<div class="box" style="max-height:300px; overflow-y:auto;">
+<div id="messages" class="box" style="max-height:300px; overflow-y:auto;">
   {% for m in messages %}
     <p><b>{{ 'Вы' if m.sender_id==current_user.id else other.username }}:</b> {{ m.text }}</p>
   {% endfor %}
 </div>
-<form method="post" class="mt-4">
+<form class="mt-4" id="sendForm">
   <b-field>
-    <b-input name="text" required></b-input>
+    <b-input id="text" required></b-input>
   </b-field>
-  <button class="button is-primary" type="submit">Отправить</button>
+  <button id="sendBtn" class="button is-primary">Отправить</button>
 </form>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+<script>
+const socket = io();
+const otherId = {{ other.id }};
+socket.emit('join', {other_id: otherId});
+socket.on('new_message', data => {
+  const div = document.getElementById('messages');
+  const p = document.createElement('p');
+  p.innerHTML = `<b>${data.sender}:</b> ${data.text}`;
+  div.appendChild(p);
+});
+document.getElementById('sendForm').addEventListener('submit', e => {
+  e.preventDefault();
+  const input = document.getElementById('text');
+  const text = input.value.trim();
+  if(!text) return;
+  socket.emit('send_message', {other_id: otherId, text});
+  input.value = '';
+});
+</script>
 {% endblock %}

--- a/webfriends/templates/create_event.html
+++ b/webfriends/templates/create_event.html
@@ -8,6 +8,16 @@
   <b-field label="Описание">
     <b-input name="description" required></b-input>
   </b-field>
+  <b-field label="Категория">
+    <b-select name="category">
+      <option value="meet">Встреча</option>
+      <option value="sport">Спорт</option>
+      <option value="party">Тусовка</option>
+    </b-select>
+  </b-field>
+  <b-field label="Безопасная точка">
+    <b-checkbox name="is_safe"></b-checkbox>
+  </b-field>
   <b-field label="Широта">
     <b-input name="lat" type="number" step="any" required></b-input>
   </b-field>

--- a/webfriends/templates/feed.html
+++ b/webfriends/templates/feed.html
@@ -4,9 +4,14 @@
 <div class="block">
   {% for p in feed %}
   <div class="box animate__animated animate__fadeInUp mb-2">
-    <h5 class="title is-6">{{ p.title }}</h5>
-    <p>{{ p.description }}</p>
+    {% if p.__class__.__name__ == 'Event' %}
+      <h5 class="title is-6">{{ p.title }} ({{ p.category }})</h5>
+      <p>{{ p.description }}</p>
+    {% else %}
+      <p><b>{{ p.user.username }}:</b> {{ p.text }}</p>
+    {% endif %}
   </div>
   {% endfor %}
 </div>
+<a href="{{ url_for('status_view') }}" class="button is-primary">Поделиться статусом</a>
 {% endblock %}

--- a/webfriends/templates/layout.html
+++ b/webfriends/templates/layout.html
@@ -38,6 +38,9 @@
             <a class="navbar-item has-text-white" href="/feed">
                 <span class="icon is-large"><i class="fas fa-stream"></i></span>
             </a>
+            <a class="navbar-item has-text-white" href="/speedmeet">
+                <span class="icon is-large"><i class="fas fa-video"></i></span>
+            </a>
             <a class="navbar-item has-text-white" href="/matches">
                 <span class="icon is-large"><i class="fas fa-handshake"></i></span>
             </a>

--- a/webfriends/templates/map.html
+++ b/webfriends/templates/map.html
@@ -16,6 +16,21 @@
       </b-select>
     </b-field>
   </div>
+  <div class="column">
+    <b-field label="Категория">
+      <b-select id="filterCategory">
+        <option value="">Все</option>
+        <option value="meet">Встреча</option>
+        <option value="sport">Спорт</option>
+        <option value="party">Тусовка</option>
+      </b-select>
+    </b-field>
+  </div>
+  <div class="column">
+    <b-field label="Безопасные">
+      <b-checkbox id="filterSafe"></b-checkbox>
+    </b-field>
+  </div>
 </div>
 <div id="map" style="height:500px;"></div>
 <a href="/create-event" class="button is-primary fab">

--- a/webfriends/templates/profile.html
+++ b/webfriends/templates/profile.html
@@ -23,6 +23,9 @@
   <b-field label="Фото профиля">
     <b-input name="photo" type="file" accept="image/*"></b-input>
   </b-field>
+  <b-field label="Доверенный пользователь (ID)">
+    <b-input name="trusted_user_id" type="number" value="{{ user.trusted_user_id }}"></b-input>
+  </b-field>
   <b-field label="Режим невидимки">
     <b-switch name="is_private" {{ 'checked' if user.is_private else '' }}></b-switch>
   </b-field>
@@ -37,6 +40,13 @@
     <img src="{{ url_for('static', filename='uploads/' + user.photo) }}" style="max-width:150px;">
   </div>
   {% endif %}
+  <p class="mb-3">
+    {% if user.is_verified %}
+      <span class="tag is-success">Профиль подтвержден</span>
+    {% else %}
+      <a href="{{ url_for('verify_view') }}" class="button is-small is-warning">Пройти верификацию</a>
+    {% endif %}
+  </p>
 <div class="mt-4">
   <button class="button is-primary" type="submit">Сохранить</button>
 </div>

--- a/webfriends/templates/speedmeet.html
+++ b/webfriends/templates/speedmeet.html
@@ -1,0 +1,28 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-3">SpeedMeet</h2>
+<div id="status">Ожидание собеседника...</div>
+<video id="remote" autoplay playsinline style="width:100%;max-height:300px"></video>
+<video id="local" autoplay muted playsinline style="width:100px"></video>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+<script src="https://unpkg.com/simple-peer@9.11.1/simplepeer.min.js"></script>
+<script>
+const socket = io();
+let peer;
+socket.emit('speed_join');
+socket.on('speed_start', data => {
+  document.getElementById('status').innerText = 'Соединение...';
+  peer = new SimplePeer({initiator: data.initiator, trickle:false, stream:null});
+  navigator.mediaDevices.getUserMedia({video:true, audio:true}).then(stream => {
+    document.getElementById('local').srcObject = stream;
+    peer.addStream(stream);
+  });
+  peer.on('signal', d => socket.emit('speed_signal', d));
+  peer.on('stream', stream => {
+    document.getElementById('remote').srcObject = stream;
+    document.getElementById('status').innerText = 'Разговор';
+  });
+});
+socket.on('speed_signal', d => peer && peer.signal(d));
+</script>
+{% endblock %}

--- a/webfriends/templates/status.html
+++ b/webfriends/templates/status.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-3">Новый статус</h2>
+<form method="post">
+  <b-field label="Статус">
+    <b-input name="text" maxlength="250" required></b-input>
+  </b-field>
+  <button class="button is-primary" type="submit">Опубликовать</button>
+</form>
+{% endblock %}

--- a/webfriends/templates/swipe.html
+++ b/webfriends/templates/swipe.html
@@ -7,6 +7,7 @@
   <p>{{ target.city }}</p>
   <div class="mt-3">
     <a class="button is-success" href="{{ url_for('like_user', user_id=target.id, action='like') }}">Нравится</a>
+    <a class="button is-warning" href="{{ url_for('like_user', user_id=target.id, action='super') }}">Супер!</a>
     <a class="button is-danger" href="{{ url_for('like_user', user_id=target.id, action='dislike') }}">Пропустить</a>
   </div>
 </div>

--- a/webfriends/templates/verify.html
+++ b/webfriends/templates/verify.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title is-4 mb-3">Верификация</h2>
+<form method="post" enctype="multipart/form-data">
+  <b-field label="Фото-селфи">
+    <b-input type="file" name="photo" required></b-input>
+  </b-field>
+  <button class="button is-primary" type="submit">Отправить</button>
+</form>
+{% endblock %}

--- a/webfriends_app.py
+++ b/webfriends_app.py
@@ -1,9 +1,11 @@
 import os
 import secrets
+import random
 from flask import Flask, render_template, jsonify, request, redirect, url_for, flash
 from werkzeug.utils import secure_filename
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user
-from webfriends.models import db, User, Event, Like, Message, Gift, UserGift, Match
+from flask_socketio import SocketIO, join_room, emit
+from webfriends.models import db, User, Event, Like, Message, Gift, UserGift, Match, Status
 
 app = Flask(__name__, template_folder='webfriends/templates', static_folder='webfriends/static')
 app.config['SECRET_KEY'] = 'dev'
@@ -11,6 +13,7 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///webfriends.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db.init_app(app)
+socketio = SocketIO(app)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 
@@ -23,6 +26,13 @@ CARDS = [
     {"id": 2, "image": "https://source.unsplash.com/random/400x300?sig=2", "question": "Какую музыку ты слушаешь?"},
     {"id": 3, "image": "https://source.unsplash.com/random/400x300?sig=3", "question": "Любимое место в городе?"},
 ]
+
+def get_chat_room(id1: int, id2: int) -> str:
+    a, b = sorted([id1, id2])
+    return f"chat_{a}_{b}"
+
+# simple in-memory queue for SpeedMeet
+speed_waiting = None  # (user_id, sid)
 
 @app.route('/')
 def index():
@@ -98,7 +108,7 @@ def map_view():
 @app.route('/events', methods=['GET'])
 def events_api():
     events = [
-        {"id": e.id, "lat": e.lat, "lng": e.lng, "title": e.title, "description": e.description, "type": "event"}
+        {"id": e.id, "lat": e.lat, "lng": e.lng, "title": e.title, "description": e.description, "type": "event", "category": e.category, "safe": e.is_safe}
         for e in Event.query.all()
     ]
     users = [
@@ -121,6 +131,8 @@ def add_event():
     event = Event(
         title=request.form['title'],
         description=request.form['description'],
+        category=request.form.get('category'),
+        is_safe=bool(request.form.get('is_safe')),
         lat=float(request.form['lat']),
         lng=float(request.form['lng']),
         creator_id=current_user.id if current_user.is_authenticated else None,
@@ -150,14 +162,15 @@ def like_user(user_id, action):
         return redirect(url_for('swipe_view'))
     like = Like.query.filter_by(user_id=current_user.id, target_id=user_id).first()
     if not like:
-        like = Like(user_id=current_user.id, target_id=user_id, liked=(action=='like'))
+        like = Like(user_id=current_user.id, target_id=user_id, liked=(action=='like'), super=(action=='super'))
         db.session.add(like)
     else:
-        like.liked = (action=='like')
+        like.liked = (action!='dislike')
+        like.super = (action=='super')
     db.session.commit()
     # check for match
-    if action == 'like':
-        back = Like.query.filter_by(user_id=user_id, target_id=current_user.id, liked=True).first()
+    if action in ['like', 'super']:
+        back = Like.query.filter_by(user_id=user_id, target_id=current_user.id).filter(Like.liked==True).first()
         if back:
             if not Match.query.filter(
                 ((Match.user1_id==current_user.id) & (Match.user2_id==user_id)) |
@@ -165,7 +178,8 @@ def like_user(user_id, action):
             ).first():
                 db.session.add(Match(user1_id=current_user.id, user2_id=user_id))
                 db.session.commit()
-            flash('У вас новый матч!')
+            q = random.choice(CARDS)['question']
+            flash('У вас новый матч! Вопрос для начала разговора: ' + q)
     return redirect(url_for('swipe_view'))
 
 
@@ -184,14 +198,32 @@ def send_gift(user_id):
             ug = UserGift(sender_id=current_user.id, recipient_id=user_id, gift_id=gift_id)
             db.session.add(ug)
             db.session.commit()
-            flash('Подарок отправлен')
+            msg = 'Подарок отправлен'
+            if g.coupon_url:
+                msg += f". Купон: {g.coupon_url}"
+            flash(msg)
             return redirect(url_for('profile_view'))
     return render_template('send_gift.html', title='Подарок', target=target, gifts=gifts)
 
 @app.route('/feed')
 def feed_view():
     events = Event.query.order_by(Event.id.desc()).all()
-    return render_template('feed.html', title='Пульс города', feed=events)
+    statuses = Status.query.order_by(Status.timestamp.desc()).limit(20).all()
+    feed = events + statuses
+    feed.sort(key=lambda x: getattr(x, 'timestamp', x.id), reverse=True)
+    return render_template('feed.html', title='Пульс города', feed=feed)
+
+
+@app.route('/status', methods=['GET', 'POST'])
+@login_required
+def status_view():
+    if request.method == 'POST':
+        text = request.form['text']
+        s = Status(user_id=current_user.id, text=text)
+        db.session.add(s)
+        db.session.commit()
+        return redirect(url_for('feed_view'))
+    return render_template('status.html', title='Статус')
 
 @app.route('/chat/<int:user_id>', methods=['GET', 'POST'])
 @login_required
@@ -201,8 +233,8 @@ def chat_view(user_id):
         flash('Пользователь не найден')
         return redirect(url_for('index'))
     # allow chat only for взаимных лайков
-    l1 = Like.query.filter_by(user_id=current_user.id, target_id=other.id, liked=True).first()
-    l2 = Like.query.filter_by(user_id=other.id, target_id=current_user.id, liked=True).first()
+    l1 = Like.query.filter_by(user_id=current_user.id, target_id=other.id).filter(Like.liked==True).first()
+    l2 = Like.query.filter_by(user_id=other.id, target_id=current_user.id).filter(Like.liked==True).first()
     if not (l1 and l2):
         flash('Чат доступен только после взаимного лайка')
         return redirect(url_for('swipe_view'))
@@ -211,6 +243,11 @@ def chat_view(user_id):
         msg = Message(sender_id=current_user.id, recipient_id=other.id, text=text)
         db.session.add(msg)
         db.session.commit()
+        room = get_chat_room(current_user.id, other.id)
+        socketio.emit('new_message', {
+            'sender': current_user.username,
+            'text': text
+        }, room=room)
         return redirect(url_for('chat_view', user_id=user_id))
     messages = Message.query.filter(
         ((Message.sender_id == current_user.id) & (Message.recipient_id == other.id)) |
@@ -274,6 +311,7 @@ def profile_view():
         current_user.about = request.form.get('about', '')
         current_user.social = request.form.get('social', '')
         current_user.is_private = bool(request.form.get('is_private'))
+        current_user.trusted_user_id = request.form.get('trusted_user_id') or None
         current_user.lat = request.form.get('lat') or None
         current_user.lng = request.form.get('lng') or None
         photo_file = request.files.get('photo')
@@ -285,6 +323,77 @@ def profile_view():
         db.session.commit()
         flash('Профиль обновлен')
     return render_template('profile.html', title='Профиль', user=current_user)
+
+
+@app.route('/verify', methods=['GET', 'POST'])
+@login_required
+def verify_view():
+    if request.method == 'POST':
+        photo = request.files.get('photo')
+        if photo and photo.filename:
+            filename = secure_filename(photo.filename)
+            upload_path = os.path.join(app.static_folder, 'uploads', filename)
+            photo.save(upload_path)
+            current_user.verification_photo = filename
+            current_user.is_verified = True
+            db.session.commit()
+            flash('Верификация пройдена')
+            return redirect(url_for('profile_view'))
+    return render_template('verify.html', title='Верификация')
+
+
+@app.route('/speedmeet')
+@login_required
+def speedmeet_view():
+    return render_template('speedmeet.html', title='SpeedMeet')
+
+
+@socketio.on('join')
+def on_join(data):
+    if not current_user.is_authenticated:
+        return
+    room = get_chat_room(current_user.id, data.get('other_id'))
+    join_room(room)
+
+
+@socketio.on('send_message')
+def on_send_message(data):
+    if not current_user.is_authenticated:
+        return
+    other_id = data.get('other_id')
+    text = data.get('text')
+    if not other_id or not text:
+        return
+    msg = Message(sender_id=current_user.id, recipient_id=other_id, text=text)
+    db.session.add(msg)
+    db.session.commit()
+    room = get_chat_room(current_user.id, other_id)
+    emit('new_message', {
+        'sender': current_user.username,
+        'text': text
+    }, room=room)
+
+
+@socketio.on('speed_join')
+def speed_join():
+    if not current_user.is_authenticated:
+        return
+    global speed_waiting
+    if speed_waiting and speed_waiting[0] != current_user.id:
+        partner_id, partner_sid = speed_waiting
+        speed_waiting = None
+        room = f"speed_{min(current_user.id, partner_id)}_{max(current_user.id, partner_id)}"
+        join_room(room, sid=request.sid)
+        join_room(room, sid=partner_sid)
+        socketio.emit('speed_start', {'initiator': False}, room=partner_sid)
+        emit('speed_start', {'initiator': True})
+    else:
+        speed_waiting = (current_user.id, request.sid)
+
+
+@socketio.on('speed_signal')
+def speed_signal(data):
+    emit('speed_signal', data, broadcast=True, include_self=False)
 
 
 @app.route('/create-event', methods=['GET', 'POST'])
@@ -302,10 +411,10 @@ def init_db_command():
         if not Gift.query.first():
             db.session.add_all([
                 Gift(name='Цветок', description='Виртуальный цветок'),
-                Gift(name='Сердце', description='Смайлик-сердечко'),
+                Gift(name='Сердце', description='Смайлик-сердечко', coupon_url='https://example.com/coupon')
             ])
             db.session.commit()
         print('Database initialized')
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    socketio.run(app, debug=True)


### PR DESCRIPTION
## Summary
- integrate Flask-SocketIO for realtime chat
- add SpeedMeet video chat page
- implement user verification and trusted contact field
- enable posting statuses to the feed
- support super‑likes and mini icebreaker questions on matches
- enhance map with categories and safe zones
- include coupon links in gifts

## Testing
- `python -m py_compile webfriends_app.py webfriends/models.py`

------
https://chatgpt.com/codex/tasks/task_e_685a528445708330b1cae8a70dd0664e